### PR TITLE
Specs/model/additional attri/store admin

### DIFF
--- a/street-goods-burger-backend/spec/models/store_admin_spec.rb
+++ b/street-goods-burger-backend/spec/models/store_admin_spec.rb
@@ -1,5 +1,5 @@
 require 'rails_helper'
 
 RSpec.describe StoreAdmin, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  # no test here no additional collumn on the StoreAdmin table
 end


### PR DESCRIPTION
just a note, informing that it has no specs. because Model generated by devise had been tested already, unless there's an additional column added to the table